### PR TITLE
ResourceView 的 CanAdjustLayout 函数位实现

### DIFF
--- a/DuiDesigner/ResourceView.cpp
+++ b/DuiDesigner/ResourceView.cpp
@@ -88,7 +88,7 @@ void CResourceViewBar::OnSize(UINT nType, int cx, int cy)
 {
 	CDockablePane::OnSize(nType, cx, cy);
 
-	if (CanAdjustLayout())
+	//if (CanAdjustLayout())
 	{
 		m_wndResourceView.SetWindowPos(NULL, 1, 1, cx - 2, cy - 2, SWP_NOACTIVATE | SWP_NOZORDER);
 	}


### PR DESCRIPTION
用于在OnSize时判断的函数, 没有实现体, 暂时注释掉, 否则编译出错
