### PR TITLE
修正UI设计工具设置透明度无效的问题

### DIFF
--- a/DuiDesigner/PropertiesWnd.cpp
+++ b/DuiDesigner/PropertiesWnd.cpp
@@ -27,7 +27,7 @@ BEGIN_MESSAGE_MAP(CPropertiesWnd, CDockablePane)
 END_MESSAGE_MAP()
 
 /////////////////////////////////////////////////////////////////////////////
-// CPropertiesWnd ÏûÏ¢´¦Àí³ÌÐò
+// CPropertiesWnd æ¶ˆæ¯å¤„ç†ç¨‹åº
 
 int CPropertiesWnd::OnCreate(LPCREATESTRUCT lpCreateStruct)
 {
@@ -164,7 +164,7 @@ void CPropertiesWnd::SetUIValue(CMFCPropertyGridProperty* pProp,int nTag)
 			if(strNewVal.IsEmpty() || pManager->FindControl(strNewVal))
 			{
 				if(!strNewVal.IsEmpty())
-					MessageBox(strNewVal + _T(" Ãû³ÆÒÑ±»ÆäËû¿Ø¼þÊ¹ÓÃ£¡"));
+					MessageBox(strNewVal + _T(" åç§°å·²è¢«å…¶ä»–æŽ§ä»¶ä½¿ç”¨ï¼"));
 				pProp->SetValue((_variant_t)pControl->GetName());
 				return;
 			}
@@ -210,6 +210,10 @@ void CPropertiesWnd::SetUIValue(CMFCPropertyGridProperty* pProp,int nTag)
 			{
 				strNewVal=_T("0");
 				pProp->SetValue((_variant_t)(LONG)0);
+			}
+			else if (alpha<=255) 
+			{
+				pProp->SetValue((_variant_t)(LONG)alpha);
 			}
 			else
 			{


### PR DESCRIPTION
原代码在分支中只判断了小于0的情况, 对于大于0的值统一设置成255. 本次修改了判断语句
