### PR TITLE
Update UILabel.cpp

### DIFF
--- a/DuiLib/Control/UILabel.cpp
+++ b/DuiLib/Control/UILabel.cpp
@@ -180,7 +180,7 @@ namespace DuiLib
 	{
 		if( _tcscmp(pstrName, _T("align")) == 0 ) {
 			if( _tcsstr(pstrValue, _T("left")) != NULL ) {
-				m_uTextStyle &= ~(DT_CENTER | DT_RIGHT | DT_VCENTER | DT_SINGLELINE);
+				m_uTextStyle &= ~(DT_CENTER | DT_RIGHT | DT_SINGLELINE);
 				m_uTextStyle |= DT_LEFT;
 			}
 			if( _tcsstr(pstrValue, _T("center")) != NULL ) {
@@ -188,21 +188,24 @@ namespace DuiLib
 				m_uTextStyle |= DT_CENTER;
 			}
 			if( _tcsstr(pstrValue, _T("right")) != NULL ) {
-				m_uTextStyle &= ~(DT_LEFT | DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+				m_uTextStyle &= ~(DT_LEFT | DT_CENTER | DT_SINGLELINE);
 				m_uTextStyle |= DT_RIGHT;
 			}
-			if( _tcsstr(pstrValue, _T("top")) != NULL ) {
-				m_uTextStyle &= ~(DT_BOTTOM | DT_VCENTER | DT_VCENTER);
-				m_uTextStyle |= (DT_TOP | DT_SINGLELINE);
-			}
-			if( _tcsstr(pstrValue, _T("vcenter")) != NULL ) {
-				m_uTextStyle &= ~(DT_TOP | DT_BOTTOM );			
-				m_uTextStyle |= (DT_CENTER | DT_VCENTER | DT_SINGLELINE);
-			}
-			if( _tcsstr(pstrValue, _T("bottom")) != NULL ) {
-				m_uTextStyle &= ~(DT_TOP | DT_VCENTER | DT_VCENTER);
-				m_uTextStyle |= (DT_BOTTOM | DT_SINGLELINE);
-			}
+		}
+		else if (_tcscmp(pstrName, _T("valign")) == 0)
+		{
+		    if (_tcsstr(pstrValue, _T("top")) != NULL) {
+		        m_uTextStyle &= ~(DT_BOTTOM | DT_VCENTER);
+		        m_uTextStyle |= (DT_TOP | DT_SINGLELINE);
+		    }
+		    if (_tcsstr(pstrValue, _T("vcenter")) != NULL) {
+		        m_uTextStyle &= ~(DT_TOP | DT_BOTTOM);
+		        m_uTextStyle |= (DT_VCENTER | DT_SINGLELINE);
+		    }
+		    if (_tcsstr(pstrValue, _T("bottom")) != NULL) {
+		        m_uTextStyle &= ~(DT_TOP | DT_VCENTER);
+		        m_uTextStyle |= (DT_BOTTOM | DT_SINGLELINE);
+		    }
 		}
 		else if( _tcscmp(pstrName, _T("endellipsis")) == 0 ) {
 			if( _tcscmp(pstrValue, _T("true")) == 0 ) m_uTextStyle |= DT_END_ELLIPSIS;


### PR DESCRIPTION
修复了Label控件设置垂直垂直对齐方式无效的bug。属性文档里Label控件拥有valign属性，但UILabel的SetAttribute()函数并没有处理。