### PR TITLE
修复当PainManager中不存在对应的语言字符串时抛出代码异常的问题

### DIFF
--- a/DuiLib/Core/UIManager.cpp
+++ b/DuiLib/Core/UIManager.cpp
@@ -2491,7 +2491,8 @@ void CPaintManagerUI::ProcessMultiLanguageTokens(CDuiString& pStrMultiLanguage)
 			while( isdigit(pStrMultiLanguage.GetAt(iEndPos)) ) iEndPos++;
 			if( pStrMultiLanguage.GetAt(iEndPos) == '}' ) {
 				LPCTSTR pStrTemp = CPaintManagerUI::GetMultiLanguageString((UINT)_ttoi(pStrMultiLanguage.GetData() + iPos + 2));
-				pStrMultiLanguage.Replace(pStrMultiLanguage.Mid(iPos, iEndPos - iPos + 1), pStrTemp);
+                if (pStrTemp)
+				    pStrMultiLanguage.Replace(pStrMultiLanguage.Mid(iPos, iEndPos - iPos + 1), pStrTemp);
 			}
 		}
 		iPos = pStrMultiLanguage.Find(_T('%'), iPos + 1);


### PR DESCRIPTION
修复当PainManager中不存在对应的语言字符串时抛出代码异常的问题