### PR TITLE
设置资源路径崩溃问题

### DIFF
--- a/DuiLib/Control/UITreeView.cpp
+++ b/DuiLib/Control/UITreeView.cpp
@@ -896,15 +896,12 @@ namespace DuiLib
 	//************************************
 	bool CTreeViewUI::Remove( CTreeNodeUI* pControl )
 	{
-		if(pControl->GetCountChild() > 0)
+		while(pControl->GetCountChild() > 0)
 		{
-			int nCount = pControl->GetCountChild();
-			for(int nIndex = 0;nIndex < nCount;nIndex++)
+			CTreeNodeUI* pNode = pControl->GetChildNode(0);
+			if(pNode)
 			{
-				CTreeNodeUI* pNode = pControl->GetChildNode(nIndex);
-				if(pNode){
-					pControl->Remove(pNode);
-				}
+				pControl->Remove(pNode);
 			}
 		}
 		CListUI::Remove(pControl);
@@ -920,9 +917,7 @@ namespace DuiLib
 	bool CTreeViewUI::RemoveAt( int iIndex )
 	{
 		CTreeNodeUI* pItem = (CTreeNodeUI*)GetItemAt(iIndex);
-		if(pItem->GetCountChild())
-			Remove(pItem);
-		return true;
+		return Remove(pItem);
 	}
 
 	void CTreeViewUI::RemoveAll()

--- a/DuiLib/Utils/WinImplBase.cpp
+++ b/DuiLib/Utils/WinImplBase.cpp
@@ -278,8 +278,12 @@ LRESULT WindowImplBase::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& 
 	m_PaintManager.AddPreMessageFilter(this);
 
 	CDialogBuilder builder;
-	CDuiString strResourcePath=m_PaintManager.GetInstancePath();
-	strResourcePath+=GetSkinFolder().GetData();
+	CDuiString strResourcePath=m_PaintManager.GetResourcePath();
+	if (strResourcePath.IsEmpty())
+	{
+		strResourcePath=m_PaintManager.GetInstancePath();
+		strResourcePath+=GetSkinFolder().GetData();
+	}
 	m_PaintManager.SetResourcePath(strResourcePath.GetData());
 
 	switch(GetResourceType())


### PR DESCRIPTION
调用SetResourcePath(CPaintManagerUI::GetInstancePath() + _T("skin"));  duilib会报错，

解决如下