### PR TITLE
为xml的编写方便，扩展了下xml的语法

### DIFF
--- a/DuiLib/Core/UIDefine.h
+++ b/DuiLib/Core/UIDefine.h
@@ -18,6 +18,12 @@ enum DuiSig
 	DuiSig_vn,      // void (TNotifyUI)
 };
 
+enum STYLE_RECT
+{
+	STYLE_RECT_LTRB = 0,  /* left,top,right,bottom */
+	STYLE_RECT_LTWH = 1   /* left,top,width,height */
+};
+
 class CControlUI;
 
 // Structure for notifications to the outside world

--- a/DuiLib/Core/UIDlgBuilder.cpp
+++ b/DuiLib/Core/UIDlgBuilder.cpp
@@ -121,7 +121,7 @@ CControlUI* CDialogBuilder::Create(IDialogBuilderCallback* pCallback, CPaintMana
                     if( defaultfont ) pManager->SetDefaultFont(pFontName, size, bold, underline, italic, shared);
                 }
             }
-            else if( _tcsicmp(pstrClass, _T("Default")) == 0 ) {
+            else if( _tcsicmp(pstrClass, _T("Default")) == 0 || _tcsicmp(pstrClass, _T("Style")) == 0) {
                 nAttributes = node.GetAttributeCount();
                 LPCTSTR pControlName = NULL;
                 LPCTSTR pControlValue = NULL;
@@ -200,8 +200,8 @@ CControlUI* CDialogBuilder::_Parse(CMarkupNode* pRoot, CControlUI* pParent, CPai
     for( CMarkupNode node = pRoot->GetChild() ; node.IsValid(); node = node.GetSibling() ) {
         LPCTSTR pstrClass = node.GetName();
         if( _tcsicmp(pstrClass, _T("Image")) == 0 || _tcsicmp(pstrClass, _T("Font")) == 0 \
-            || _tcsicmp(pstrClass, _T("Default")) == 0 
-			|| _tcsicmp(pstrClass, _T("MultiLanguage")) == 0 ) continue;
+            || _tcsicmp(pstrClass, _T("Default")) == 0 || _tcsicmp(pstrClass, _T("Style")) == 0 \
+                || _tcsicmp(pstrClass, _T("MultiLanguage")) == 0 ) continue;
 
         CControlUI* pControl = NULL;
         if( _tcsicmp(pstrClass, _T("Include")) == 0 ) {
@@ -248,12 +248,41 @@ CControlUI* CDialogBuilder::_Parse(CMarkupNode* pRoot, CControlUI* pParent, CPai
 
 			// 解析所有属性并覆盖默认属性
 			if( node.HasAttributes() ) {
-				TCHAR szValue[500] = { 0 };
-				SIZE_T cchLen = lengthof(szValue) - 1;
 				// Set ordinary attributes
 				int nAttributes = node.GetAttributeCount();
 				for( int i = 0; i < nAttributes; i++ ) {
-					pNode->SetAttribute(node.GetAttributeName(i), node.GetAttributeValue(i));
+					LPCTSTR pstrName = node.GetAttributeName(i);
+					LPCTSTR pstrValue = node.GetAttributeValue(i);
+
+					// 设置风格属性
+					if(_tcsicmp(pstrName, _T("style")) == 0 ) {
+						TCHAR szValue[500] = { 0 };
+						SIZE_T cchLen = lengthof(szValue) - 1;
+						bool hasFmt = node.GetAttributeValue(_T("styleref"), szValue, cchLen);
+
+						if( pManager ) {
+							LPCTSTR pStyleAttributes = pManager->GetDefaultAttributeList(pstrValue);
+							if (pStyleAttributes) {
+								if( hasFmt ) {
+									CDuiString sStyleFormat(pStyleAttributes);
+									CDuiString sStyleRef(szValue);
+									int iStart = 0, iPos = sStyleRef.Find(_T(','));
+									do
+									{
+										CDuiString sTemp = sStyleRef.Mid(iStart, iPos - iStart);
+										sStyleFormat.Replace(_T("%s"), sTemp, 1);
+										iStart = iPos + 1;
+										iPos = sStyleRef.Find(_T(','), iStart);
+									} while (iPos >= 0);
+									pStyleAttributes = sStyleFormat.GetData();
+								}
+								pNode->ApplyAttributeList(pStyleAttributes);
+							}
+						}
+					}
+					else if( _tcsicmp(pstrName, _T("styleref")) != 0 ) {
+						pNode->SetAttribute(pstrName, pstrValue);
+					}
 				}
 			}
 
@@ -417,7 +446,38 @@ CControlUI* CDialogBuilder::_Parse(CMarkupNode* pRoot, CControlUI* pParent, CPai
             // Set ordinary attributes
             int nAttributes = node.GetAttributeCount();
             for( int i = 0; i < nAttributes; i++ ) {
-                pControl->SetAttribute(node.GetAttributeName(i), node.GetAttributeValue(i));
+                LPCTSTR pstrName = node.GetAttributeName(i);
+                LPCTSTR pstrValue = node.GetAttributeValue(i);
+
+                // 设置风格属性
+                if( _tcsicmp(pstrName, _T("style")) == 0 ) {
+                    TCHAR szValue[500] = { 0 };
+                    SIZE_T cchLen = lengthof(szValue) - 1;
+                    bool hasFmt = node.GetAttributeValue(_T("styleref"), szValue, cchLen);
+
+                    if( pManager ) {
+                        LPCTSTR pStyleAttributes = pManager->GetDefaultAttributeList(pstrValue);
+                        if( pStyleAttributes ) {
+                            if( hasFmt ) {
+                                CDuiString sStyleFormat(pStyleAttributes);
+                                CDuiString sStyleRef(szValue);
+                                int iStart = 0, iPos = 0;
+                                do
+                                {
+                                    iPos = sStyleRef.Find(_T(','), iStart);
+                                    CDuiString sTemp = sStyleRef.Mid(iStart, iPos - iStart);
+                                    sStyleFormat.Replace(_T("%s"), sTemp, 1);
+                                    iStart = iPos + 1;
+                                } while (iPos >= 0);
+                                pStyleAttributes = sStyleFormat.GetData();
+                            }
+                            pControl->ApplyAttributeList(pStyleAttributes);
+                        }
+                    }
+                }
+                else if( _tcsicmp(pstrName, _T("styleref")) != 0 ) {
+                    pControl->SetAttribute(pstrName, pstrValue);
+                }
             }
         }
         if( pManager ) {

--- a/DuiLib/Core/UIDlgBuilder.cpp
+++ b/DuiLib/Core/UIDlgBuilder.cpp
@@ -2,6 +2,8 @@
 
 namespace DuiLib {
 
+extern int g_rectStyle;
+
 CDialogBuilder::CDialogBuilder() : m_pCallback(NULL), m_pstrtype(NULL)
 {
 
@@ -125,7 +127,8 @@ CControlUI* CDialogBuilder::Create(IDialogBuilderCallback* pCallback, CPaintMana
                 nAttributes = node.GetAttributeCount();
                 LPCTSTR pControlName = NULL;
                 LPCTSTR pControlValue = NULL;
-				bool shared = false;
+                LPCTSTR pRectStyle = NULL;
+                bool shared = false;
                 for( int i = 0; i < nAttributes; i++ ) {
                     pstrName = node.GetAttributeName(i);
                     pstrValue = node.GetAttributeValue(i);
@@ -135,12 +138,20 @@ CControlUI* CDialogBuilder::Create(IDialogBuilderCallback* pCallback, CPaintMana
                     else if( _tcsicmp(pstrName, _T("value")) == 0 ) {
                         pControlValue = pstrValue;
                     }
-					else if( _tcsicmp(pstrName, _T("shared")) == 0 ) {
-						shared = (_tcsicmp(pstrValue, _T("true")) == 0);
-					}
+                    else if( _tcsicmp(pstrName, _T("shared")) == 0 ) {
+                        shared = (_tcsicmp(pstrValue, _T("true")) == 0);
+                    }
+                    else if( _tcsicmp(pstrName, _T("rectstyle")) == 0 ) {
+                        pRectStyle = pstrValue;
+                    }
                 }
                 if( pControlName ) {
                     pManager->AddDefaultAttributeList(pControlName, pControlValue, shared);
+                }
+                else if( pRectStyle ) {
+                    if( _tcsicmp(pRectStyle, _T("l,t,w,h") ) == 0) {
+                        g_rectStyle = STYLE_RECT_LTWH;
+                    }
                 }
             }
 			else if( _tcsicmp(pstrClass, _T("MultiLanguage")) == 0 ) {

--- a/DuiLib/Core/UIManager.cpp
+++ b/DuiLib/Core/UIManager.cpp
@@ -2669,6 +2669,9 @@ const TImageInfo* CPaintManagerUI::AddImage(LPCTSTR bitmap, LPCTSTR type, DWORD 
             int iIndex = _tcstol(bitmap, &pstr, 10);
             data = CRenderEngine::LoadImage(iIndex, type, mask);
         }
+        else {
+            data = CRenderEngine::LoadImage(bitmap, type, mask);
+        }
     }
     else {
         data = CRenderEngine::LoadImage(bitmap, NULL, mask);

--- a/DuiLib/Core/UIRender.cpp
+++ b/DuiLib/Core/UIRender.cpp
@@ -53,7 +53,7 @@ extern "C"
 namespace DuiLib {
 
 static int g_iFontID = MAX_FONT_ID;
-
+int g_rectStyle = STYLE_RECT_LTRB;
 /////////////////////////////////////////////////////////////////////////////////////
 //
 //
@@ -1044,12 +1044,20 @@ bool CRenderEngine::DrawImage(HDC hDC, CPaintManagerUI* pManager, const RECT& rc
 					drawInfo.rcDestOffset.top = _tcstol(pstr + 1, &pstr, 10);    ASSERT(pstr);
 					drawInfo.rcDestOffset.right = _tcstol(pstr + 1, &pstr, 10);  ASSERT(pstr);
 					drawInfo.rcDestOffset.bottom = _tcstol(pstr + 1, &pstr, 10); ASSERT(pstr);
+					if( g_rectStyle == STYLE_RECT_LTWH ) {
+						drawInfo.rcDestOffset.right += drawInfo.rcDestOffset.left;
+						drawInfo.rcDestOffset.bottom += drawInfo.rcDestOffset.top;
+					}
 				}
 				else if( sItem == _T("source") ) {
 					drawInfo.rcBmpPart.left = _tcstol(sValue.GetData(), &pstr, 10);  ASSERT(pstr);    
 					drawInfo.rcBmpPart.top = _tcstol(pstr + 1, &pstr, 10);    ASSERT(pstr);    
 					drawInfo.rcBmpPart.right = _tcstol(pstr + 1, &pstr, 10);  ASSERT(pstr);    
 					drawInfo.rcBmpPart.bottom = _tcstol(pstr + 1, &pstr, 10); ASSERT(pstr);  
+					if( g_rectStyle == STYLE_RECT_LTWH ) {
+						drawInfo.rcBmpPart.right += drawInfo.rcBmpPart.left;
+						drawInfo.rcBmpPart.bottom += drawInfo.rcBmpPart.top;
+					}
 				}
 				else if( sItem == _T("corner") || sItem == _T("scale9")) {
 					drawInfo.rcScale9.left = _tcstol(sValue.GetData(), &pstr, 10);  ASSERT(pstr);    

--- a/DuiLib/Utils/Utils.cpp
+++ b/DuiLib/Utils/Utils.cpp
@@ -749,7 +749,7 @@ namespace DuiLib
 		return (int)(p - m_pstr);
 	}
 
-	int CDuiString::Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo)
+	int CDuiString::Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo, int count)
 	{
 		CDuiString sTemp;
 		int nCount = 0;
@@ -764,6 +764,7 @@ namespace DuiLib
 			Assign(sTemp);
 			iPos = Find(pstrFrom, iPos + cchTo);
 			nCount++;
+			if (nCount == count) return nCount;
 		}
 		return nCount;
 	}

--- a/DuiLib/Utils/Utils.h
+++ b/DuiLib/Utils/Utils.h
@@ -133,7 +133,7 @@ namespace DuiLib
         int Find(TCHAR ch, int iPos = 0) const;
         int Find(LPCTSTR pstr, int iPos = 0) const;
         int ReverseFind(TCHAR ch) const;
-        int Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo);
+		int Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo, int count = -1);
 
         int __cdecl Format(LPCTSTR pstrFormat, ...);
         int __cdecl SmallFormat(LPCTSTR pstrFormat, ...);


### PR DESCRIPTION
通过修改xml文件属性的解析/处理，增加了风格定义。

- 增加Style关键字可对一系列控件设置属性 (与Default功能相同，但是对象不同)
- Style定义的属性可使用%s占位，根据各个控件的styleref值填充
-图像source,dest属性可以使用left,top,width,height风格(原风格为left,top,right,bottom,需要计算)
- image除了file以外，增加color属性，可以直接得到1x1的纯色图像

PS:对以前的格式的使用没有影响。