### PR TITLE
为xml的编写方便，扩展了下xml的语法

### DIFF
--- a/DuiLib/Core/UIDefine.h
+++ b/DuiLib/Core/UIDefine.h
@@ -18,6 +18,12 @@ enum DuiSig
 	DuiSig_vn,      // void (TNotifyUI)
 };
 
+enum STYLE_RECT
+{
+	STYLE_RECT_LTRB = 0,  /* left,top,right,bottom */
+	STYLE_RECT_LTWH = 1   /* left,top,width,height */
+};
+
 class CControlUI;
 
 // Structure for notifications to the outside world

--- a/DuiLib/Core/UIDlgBuilder.cpp
+++ b/DuiLib/Core/UIDlgBuilder.cpp
@@ -2,6 +2,8 @@
 
 namespace DuiLib {
 
+extern int g_rectStyle;
+
 CDialogBuilder::CDialogBuilder() : m_pCallback(NULL), m_pstrtype(NULL)
 {
 
@@ -125,7 +127,8 @@ CControlUI* CDialogBuilder::Create(IDialogBuilderCallback* pCallback, CPaintMana
                 nAttributes = node.GetAttributeCount();
                 LPCTSTR pControlName = NULL;
                 LPCTSTR pControlValue = NULL;
-				bool shared = false;
+                LPCTSTR pRectStyle = NULL;
+                bool shared = false;
                 for( int i = 0; i < nAttributes; i++ ) {
                     pstrName = node.GetAttributeName(i);
                     pstrValue = node.GetAttributeValue(i);
@@ -135,12 +138,20 @@ CControlUI* CDialogBuilder::Create(IDialogBuilderCallback* pCallback, CPaintMana
                     else if( _tcsicmp(pstrName, _T("value")) == 0 ) {
                         pControlValue = pstrValue;
                     }
-					else if( _tcsicmp(pstrName, _T("shared")) == 0 ) {
-						shared = (_tcsicmp(pstrValue, _T("true")) == 0);
-					}
+                    else if( _tcsicmp(pstrName, _T("shared")) == 0 ) {
+                        shared = (_tcsicmp(pstrValue, _T("true")) == 0);
+                    }
+                    else if( _tcsicmp(pstrName, _T("rectstyle")) == 0 ) {
+                        pRectStyle = pstrValue;
+                    }
                 }
                 if( pControlName ) {
                     pManager->AddDefaultAttributeList(pControlName, pControlValue, shared);
+                }
+                else if( pRectStyle ) {
+                    if( _tcsicmp(pRectStyle, _T("l,t,w,h") ) == 0) {
+                        g_rectStyle = STYLE_RECT_LTWH;
+                    }
                 }
             }
 			else if( _tcsicmp(pstrClass, _T("MultiLanguage")) == 0 ) {

--- a/DuiLib/Core/UIManager.cpp
+++ b/DuiLib/Core/UIManager.cpp
@@ -2669,6 +2669,9 @@ const TImageInfo* CPaintManagerUI::AddImage(LPCTSTR bitmap, LPCTSTR type, DWORD 
             int iIndex = _tcstol(bitmap, &pstr, 10);
             data = CRenderEngine::LoadImage(iIndex, type, mask);
         }
+        else {
+            data = CRenderEngine::LoadImage(bitmap, type, mask);
+        }
     }
     else {
         data = CRenderEngine::LoadImage(bitmap, NULL, mask);
@@ -2856,6 +2859,9 @@ void CPaintManagerUI::ReloadSharedImages()
 						int iIndex = _tcstol(bitmap, &pstr, 10);
 						pNewData = CRenderEngine::LoadImage(iIndex, data->sResType.GetData(), data->dwMask);
 					}
+					else {
+						pNewData = CRenderEngine::LoadImage(bitmap, data->sResType.GetData(), data->dwMask);
+					}
 				}
 				else {
 					pNewData = CRenderEngine::LoadImage(bitmap, NULL, data->dwMask);
@@ -2895,6 +2901,9 @@ void CPaintManagerUI::ReloadImages()
 						LPTSTR pstr = NULL;
 						int iIndex = _tcstol(bitmap, &pstr, 10);
 						pNewData = CRenderEngine::LoadImage(iIndex, data->sResType.GetData(), data->dwMask);
+					}
+					else {
+						pNewData = CRenderEngine::LoadImage(bitmap, data->sResType.GetData(), data->dwMask);
 					}
 				}
 				else {

--- a/DuiLib/Core/UIRender.cpp
+++ b/DuiLib/Core/UIRender.cpp
@@ -53,7 +53,7 @@ extern "C"
 namespace DuiLib {
 
 static int g_iFontID = MAX_FONT_ID;
-
+int g_rectStyle = STYLE_RECT_LTRB;
 /////////////////////////////////////////////////////////////////////////////////////
 //
 //
@@ -1044,12 +1044,20 @@ bool CRenderEngine::DrawImage(HDC hDC, CPaintManagerUI* pManager, const RECT& rc
 					drawInfo.rcDestOffset.top = _tcstol(pstr + 1, &pstr, 10);    ASSERT(pstr);
 					drawInfo.rcDestOffset.right = _tcstol(pstr + 1, &pstr, 10);  ASSERT(pstr);
 					drawInfo.rcDestOffset.bottom = _tcstol(pstr + 1, &pstr, 10); ASSERT(pstr);
+					if( g_rectStyle == STYLE_RECT_LTWH ) {
+						drawInfo.rcDestOffset.right += drawInfo.rcDestOffset.left;
+						drawInfo.rcDestOffset.bottom += drawInfo.rcDestOffset.top;
+					}
 				}
 				else if( sItem == _T("source") ) {
 					drawInfo.rcBmpPart.left = _tcstol(sValue.GetData(), &pstr, 10);  ASSERT(pstr);    
 					drawInfo.rcBmpPart.top = _tcstol(pstr + 1, &pstr, 10);    ASSERT(pstr);    
 					drawInfo.rcBmpPart.right = _tcstol(pstr + 1, &pstr, 10);  ASSERT(pstr);    
 					drawInfo.rcBmpPart.bottom = _tcstol(pstr + 1, &pstr, 10); ASSERT(pstr);  
+					if( g_rectStyle == STYLE_RECT_LTWH ) {
+						drawInfo.rcBmpPart.right += drawInfo.rcBmpPart.left;
+						drawInfo.rcBmpPart.bottom += drawInfo.rcBmpPart.top;
+					}
 				}
 				else if( sItem == _T("corner") || sItem == _T("scale9")) {
 					drawInfo.rcScale9.left = _tcstol(sValue.GetData(), &pstr, 10);  ASSERT(pstr);    

--- a/DuiLib/Core/UIRender.cpp
+++ b/DuiLib/Core/UIRender.cpp
@@ -40,6 +40,8 @@ extern ZRESULT FindZipItemW(HZIP hz, const TCHAR *name, bool ic, int *index, ZIP
 extern ZRESULT UnzipItem(HZIP hz, int index, void *dst, unsigned int len, DWORD flags);
 ///////////////////////////////////////////////////////////////////////////////////////
 
+#define RES_TYPE_COLOR _T("*COLOR*")
+
 extern "C"
 {
     extern unsigned char *stbi_load_from_memory(unsigned char const *buffer, int len, int *x, int *y, \
@@ -380,6 +382,9 @@ TImageInfo* CRenderEngine::LoadImage(STRINGorID bitmap, LPCTSTR type, DWORD mask
 				if( !CPaintManagerUI::IsCachedResourceZip() ) CloseZip(hz);
 			}
 		}
+		else if (_tcscmp(type, RES_TYPE_COLOR) == 0) {
+			pData = (PBYTE)0x1;  /* dummy pointer */
+		}
 		else {
 			HRSRC hResource = ::FindResource(CPaintManagerUI::GetResourceDll(), bitmap.m_lpstr, type);
 			if( hResource == NULL ) break;
@@ -424,14 +429,15 @@ TImageInfo* CRenderEngine::LoadImage(STRINGorID bitmap, LPCTSTR type, DWORD mask
 	}
 
     LPBYTE pImage = NULL;
-    int x,y,n;
-    pImage = stbi_load_from_memory(pData, dwSize, &x, &y, &n, 4);
-    delete[] pData;
-	if( !pImage ) {
-		//::MessageBox(0, _T("½âÎöÍ¼Æ¬Ê§°Ü"), _T("×¥BUG"), MB_OK);
-		return NULL;
-	}
-
+    int x = 1, y = 1, n;
+    if (!type || _tcscmp(type, RES_TYPE_COLOR) != 0) {
+        pImage = stbi_load_from_memory(pData, dwSize, &x, &y, &n, 4);
+        delete[] pData;
+        if( !pImage ) {
+            //::MessageBox(0, _T("½âÎöÍ¼Æ¬Ê§°Ü"), _T("×¥BUG"), MB_OK);
+            return NULL;
+        }
+    }
     BITMAPINFO bmi;
     ::ZeroMemory(&bmi, sizeof(BITMAPINFO));
     bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
@@ -449,6 +455,22 @@ TImageInfo* CRenderEngine::LoadImage(STRINGorID bitmap, LPCTSTR type, DWORD mask
 		//::MessageBox(0, _T("CreateDIBSectionÊ§°Ü"), _T("×¥BUG"), MB_OK);
 		return NULL;
 	}
+
+    BYTE bColorBits[4] = { 0 };
+    if (type && _tcscmp(type, RES_TYPE_COLOR) == 0) {
+        LPTSTR pstr = NULL;
+        LPCTSTR pstrValue = bitmap.m_lpstr;
+        if (*pstrValue == _T('#')) pstrValue = ::CharNext(pstrValue);
+        DWORD clrColor = _tcstoul(pstrValue, &pstr, 16);
+
+        pImage = (LPBYTE)&clrColor;
+        /* BGRA -> RGBA */
+        bColorBits[3] = pImage[3];
+        bColorBits[2] = pImage[0];
+        bColorBits[1] = pImage[1];
+        bColorBits[0] = pImage[2];
+        pImage = bColorBits;
+    }
 
     for( int i = 0; i < x * y; i++ ) 
     {
@@ -476,7 +498,9 @@ TImageInfo* CRenderEngine::LoadImage(STRINGorID bitmap, LPCTSTR type, DWORD mask
         }
     }
 
-    stbi_image_free(pImage);
+    if (!type || _tcscmp(type, RES_TYPE_COLOR) != 0) {
+        stbi_image_free(pImage);
+    }
 
 	TImageInfo* data = new TImageInfo;
 	data->hBitmap = hBitmap;
@@ -1009,6 +1033,11 @@ bool CRenderEngine::DrawImage(HDC hDC, CPaintManagerUI* pManager, const RECT& rc
 				}
 				else if( sItem == _T("restype") ) {
 					sImageResType = sValue;
+				}
+				else if (sItem == _T("color")) {
+					bUseRes = true;
+					sImageResType = RES_TYPE_COLOR;
+					sImageName = sValue;
 				}
 				else if( sItem == _T("dest") ) {
 					drawInfo.rcDestOffset.left = _tcstol(sValue.GetData(), &pstr, 10);  ASSERT(pstr);    

--- a/DuiLib/Utils/Utils.cpp
+++ b/DuiLib/Utils/Utils.cpp
@@ -749,7 +749,7 @@ namespace DuiLib
 		return (int)(p - m_pstr);
 	}
 
-	int CDuiString::Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo)
+	int CDuiString::Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo, int count)
 	{
 		CDuiString sTemp;
 		int nCount = 0;
@@ -764,6 +764,7 @@ namespace DuiLib
 			Assign(sTemp);
 			iPos = Find(pstrFrom, iPos + cchTo);
 			nCount++;
+			if( nCount == count ) return nCount;
 		}
 		return nCount;
 	}

--- a/DuiLib/Utils/Utils.h
+++ b/DuiLib/Utils/Utils.h
@@ -133,7 +133,7 @@ namespace DuiLib
         int Find(TCHAR ch, int iPos = 0) const;
         int Find(LPCTSTR pstr, int iPos = 0) const;
         int ReverseFind(TCHAR ch) const;
-        int Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo);
+		int Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo, int count = -1);
 
         int __cdecl Format(LPCTSTR pstrFormat, ...);
         int __cdecl SmallFormat(LPCTSTR pstrFormat, ...);


### PR DESCRIPTION
通过修改xml文件属性的解析/处理，增加了风格定义。

- 增加Style关键字可对一系列控件设置属性 (与Default功能相同，但是对象不同)
- Style定义的属性可使用%s占位，根据各个控件的styleref值填充
- 图像source,dest属性可以使用left,top,width,height风格(原风格为left,top,right,bottom,需要计算)
- image除了file以外，增加color属性，可以直接得到1x1的纯色图像

PS:对以前的格式的使用没有影响。