### PR TITLE
增加Style类型，可为多个类似控件定义风格

### DIFF
--- a/DuiLib/Core/UIDefine.h
+++ b/DuiLib/Core/UIDefine.h
@@ -18,6 +18,12 @@ enum DuiSig
 	DuiSig_vn,      // void (TNotifyUI)
 };
 
+enum STYLE_RECT
+{
+	STYLE_RECT_LTRB = 0,  /* left,top,right,bottom */
+	STYLE_RECT_LTWH = 1   /* left,top,width,height */
+};
+
 class CControlUI;
 
 // Structure for notifications to the outside world

--- a/DuiLib/Core/UIRender.cpp
+++ b/DuiLib/Core/UIRender.cpp
@@ -51,7 +51,7 @@ extern "C"
 namespace DuiLib {
 
 static int g_iFontID = MAX_FONT_ID;
-
+int g_imageRectStyle = STYLE_RECT_LTRB;
 /////////////////////////////////////////////////////////////////////////////////////
 //
 //
@@ -1015,12 +1015,20 @@ bool CRenderEngine::DrawImage(HDC hDC, CPaintManagerUI* pManager, const RECT& rc
 					drawInfo.rcDestOffset.top = _tcstol(pstr + 1, &pstr, 10);    ASSERT(pstr);
 					drawInfo.rcDestOffset.right = _tcstol(pstr + 1, &pstr, 10);  ASSERT(pstr);
 					drawInfo.rcDestOffset.bottom = _tcstol(pstr + 1, &pstr, 10); ASSERT(pstr);
+					if( g_imageRectStyle == STYLE_RECT_LTWH ) {
+						drawInfo.rcDestOffset.right += drawInfo.rcDestOffset.left;
+						drawInfo.rcDestOffset.bottom += drawInfo.rcDestOffset.top;
+					}
 				}
 				else if( sItem == _T("source") ) {
 					drawInfo.rcBmpPart.left = _tcstol(sValue.GetData(), &pstr, 10);  ASSERT(pstr);    
 					drawInfo.rcBmpPart.top = _tcstol(pstr + 1, &pstr, 10);    ASSERT(pstr);    
 					drawInfo.rcBmpPart.right = _tcstol(pstr + 1, &pstr, 10);  ASSERT(pstr);    
 					drawInfo.rcBmpPart.bottom = _tcstol(pstr + 1, &pstr, 10); ASSERT(pstr);  
+					if( g_imageRectStyle == STYLE_RECT_LTWH ) {
+						drawInfo.rcBmpPart.right += drawInfo.rcBmpPart.left;
+						drawInfo.rcBmpPart.bottom += drawInfo.rcBmpPart.top;
+					}
 				}
 				else if( sItem == _T("corner") || sItem == _T("scale9")) {
 					drawInfo.rcScale9.left = _tcstol(sValue.GetData(), &pstr, 10);  ASSERT(pstr);    

--- a/DuiLib/Utils/Utils.cpp
+++ b/DuiLib/Utils/Utils.cpp
@@ -749,7 +749,7 @@ namespace DuiLib
 		return (int)(p - m_pstr);
 	}
 
-	int CDuiString::Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo)
+	int CDuiString::Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo, int count)
 	{
 		CDuiString sTemp;
 		int nCount = 0;
@@ -764,6 +764,7 @@ namespace DuiLib
 			Assign(sTemp);
 			iPos = Find(pstrFrom, iPos + cchTo);
 			nCount++;
+			if( nCount == count ) return nCount;
 		}
 		return nCount;
 	}

--- a/DuiLib/Utils/Utils.h
+++ b/DuiLib/Utils/Utils.h
@@ -133,7 +133,7 @@ namespace DuiLib
         int Find(TCHAR ch, int iPos = 0) const;
         int Find(LPCTSTR pstr, int iPos = 0) const;
         int ReverseFind(TCHAR ch) const;
-        int Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo);
+		int Replace(LPCTSTR pstrFrom, LPCTSTR pstrTo, int count = -1);
 
         int __cdecl Format(LPCTSTR pstrFormat, ...);
         int __cdecl SmallFormat(LPCTSTR pstrFormat, ...);


### PR DESCRIPTION
- 增加Style类型，可为多个类似控件定义风格

- 可以改变图像的source,dest的属性风格为left,top,width,height

*使用方法如下:
```
<Style imagerectstyle="l,t,w,h" /> ★没有name属性的Style元素才生效,此为全局风格
<Style share="true" name="LTNavOpt" value="width=&quot;100&quot; height=&quot;60&quot; group=&quot;LTNav&quot; name=&quot;SM:LTNav:%s&quot; foreimage=&quot;file='Navi_%s.png' dest='26,0,48,48'&quot; selectedimage=&quot;color='#FF0000F0' dest='0,54,100,6'&quot; hotimage=&quot;color='#FF00F000' dest='0,54,100,6'&quot;" />

<Option styleref="Favorite,Favorite" style="LTNavOpt" selected="true" />
<Option styleref="Apps,Apps" style="LTNavOpt" />
<Option styleref="Refresh,Refresh" style="LTNavOpt" />
```