### PR TITLE
修复 ScrollBar 在不显示按钮时滚动速率不正确的问题

### DIFF
--- a/DuiLib/Control/UIScrollBar.cpp
+++ b/DuiLib/Control/UIScrollBar.cpp
@@ -735,7 +735,11 @@ void CScrollBarUI::DoEvent(TEventUI& event)
 		if( (m_uThumbState & UISTATE_CAPTURED) != 0 ) {
 			if( !m_bHorizontal ) {
 
-				int vRange = m_rcItem.bottom - m_rcItem.top - m_rcThumb.bottom + m_rcThumb.top - 2 * m_cxyFixed.cx;
+				int vRange = m_rcItem.bottom - m_rcItem.top - m_rcThumb.bottom + m_rcThumb.top;
+				if( m_bShowButton1 )
+					vRange -= m_cxyFixed.cx;
+				if( m_bShowButton2 )
+					vRange -= m_cxyFixed.cx;
 
 				if (vRange != 0)
 					m_nLastScrollOffset = (event.ptMouse.y - ptLastMouse.y) * m_nRange / vRange;
@@ -743,7 +747,11 @@ void CScrollBarUI::DoEvent(TEventUI& event)
 			}
 			else {
 
-				int hRange = m_rcItem.right - m_rcItem.left - m_rcThumb.right + m_rcThumb.left - 2 * m_cxyFixed.cy;
+				int hRange = m_rcItem.right - m_rcItem.left - m_rcThumb.right + m_rcThumb.left;
+				if( m_bShowButton1 )
+					hRange -= m_cxyFixed.cy;
+				if( m_bShowButton2 )
+					hRange -= m_cxyFixed.cy;
 
 				if (hRange != 0)
 					m_nLastScrollOffset = (event.ptMouse.x - ptLastMouse.x) * m_nRange / hRange;


### PR DESCRIPTION
ScrollBar 的滚动范围没有正确计算 ShowButton1 和 ShowButton2 的影响，导致当设置了  ShowButton1=false 或 ShowButton2=false 的时候，滚动条滚动的速率会比鼠标拖动的速率略快一点