### PR TITLE
定义宏 DUI_DEPRECATED 用于将不建议使用的方法标记为已弃用

### DIFF
--- a/DuiLib/Control/UIOption.cpp
+++ b/DuiLib/Control/UIOption.cpp
@@ -151,9 +151,14 @@ namespace DuiLib
 		m_dwSelectedBkColor = dwBkColor;
 	}
 
-	DWORD COptionUI::GetSelectBkColor()
+	DWORD COptionUI::GetSelectedBkColor()
 	{
 		return m_dwSelectedBkColor;
+	}
+
+	DUI_DEPRECATED DWORD COptionUI::GetSelectBkColor()
+	{
+		return this->GetSelectedBkColor();
 	}
 
 	LPCTSTR COptionUI::GetForeImage()

--- a/DuiLib/Control/UIOption.h
+++ b/DuiLib/Control/UIOption.h
@@ -29,7 +29,8 @@ namespace DuiLib
 		DWORD GetSelectedTextColor();
 
 		void SetSelectedBkColor(DWORD dwBkColor);
-		DWORD GetSelectBkColor();
+		DWORD GetSelectedBkColor();
+		DUI_DEPRECATED DWORD GetSelectBkColor(); // deprecated, use GetSelectedBkColor instead
 
 		LPCTSTR GetForeImage();
 		void SetForeImage(LPCTSTR pStrImage);

--- a/DuiLib/Core/UIDefine.h
+++ b/DuiLib/Core/UIDefine.h
@@ -217,6 +217,18 @@ protected:                                                                \
 	{ DUI_MSGTYPE_TIMER, _T(""), DuiSig_vn,(DUI_PMSG)&OnTimer },          \
 
 
+// Mark method as deprecated.
+// example: DUI_DEPRECATED void func();
+#if defined(_MSC_VER)
+#  define DUI_DEPRECATED __declspec(deprecated)
+#elif defined(__GNUC__)
+#  define DUI_DEPRECATED __attribute__ ((deprecated))
+#else
+#  pragma message("WARNING: You need to implement DUI_DEPRECATED for this compiler")
+#  define DUI_DEPRECATED
+#endif
+
+
 ///
 //////////////END消息映射宏定义////////////////////////////////////////////////////
 


### PR DESCRIPTION
定义宏 DUI_DEPRECATED 主要是借鉴了国外一些开源库的接口维护方式，对在新版本中不建议使用的接口给提示，当用户用到这些接口编译就会给出 warn 警告。这种方式方便后期接口维护，在新版本的不断演进中也保持着对早期版本的兼容。
