### PR TITLE
修复滚动条hot状态退出异常的问题；修复combo下拉框滚动条的问题，完善了combo的一些属性。

### DIFF
--- a/DuiLib/Control/UICombo.cpp
+++ b/DuiLib/Control/UICombo.cpp
@@ -118,7 +118,7 @@ bool CComboBodyUI::DoPaint(HDC hDC, const RECT& rcPaint, CControlUI* pStopContro
 //
 //
 
-class CComboWnd : public CWindowWnd
+class CComboWnd : public CWindowWnd ,public INotifyUI
 {
 public:
     void Init(CComboUI* pOwner);
@@ -126,6 +126,7 @@ public:
     void OnFinalMessage(HWND hWnd);
 
     LRESULT HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam);
+	void Notify(TNotifyUI& msg);
 
     void EnsureVisible(int iIndex);
     void Scroll(int dx, int dy);
@@ -192,6 +193,13 @@ void CComboWnd::Init(CComboUI* pOwner)
     //::SendMessage(hWndParent, WM_NCACTIVATE, TRUE, 0L);
 }
 
+void CComboWnd::Notify(TNotifyUI& msg)
+{
+	if (msg.sType == DUI_MSGTYPE_ITEMCLICK || msg.sType == DUI_MSGTYPE_ITEMACTIVATE || msg.sType == DUI_MSGTYPE_LINK ||		//ListElement的一些事件
+		msg.sType == DUI_MSGTYPE_CLICK)																						//Button的一些事件,其他一些控件一般不会用作combo的item,因此一些事件也没有进行转发,可根据需要增删
+		m_pOwner->GetManager()->SendNotify(msg.pSender,msg.sType,msg.wParam,msg.lParam,true);	
+}
+
 LPCTSTR CComboWnd::GetWindowClassName() const
 {
     return _T("ComboWnd");
@@ -230,7 +238,28 @@ LRESULT CComboWnd::HandleMessage(UINT uMsg, WPARAM wParam, LPARAM lParam)
             m_pLayout->Add(static_cast<CControlUI*>(m_pOwner->GetItemAt(i)));
         }
         m_pm.AttachDialog(m_pLayout);
-        
+		m_pm.AddNotifier(this);
+		
+		m_pLayout->SetAttribute(_T("vscrollbar"),m_pOwner->GetVscrollbar());
+		m_pLayout->SetAttribute(_T("hscrollbar"),m_pOwner->GetHscrollbar());
+		m_pLayout->SetAttribute(_T("vscrollbarstyle"),m_pOwner->GetVscrollStyle());
+		m_pLayout->SetAttribute(_T("hscrollbarstyle"),m_pOwner->GetHscrollStyle());
+		CScrollBarUI* pVerticalScrollBar = m_pLayout->GetVerticalScrollBar();
+		if (pVerticalScrollBar)
+		{
+			LPCTSTR pDefaultAttributes = m_pOwner->GetManager()->GetDefaultAttributeList(_T("VScrollBar"));
+			if( pDefaultAttributes )
+				pVerticalScrollBar->SetAttributeList(pDefaultAttributes);
+		}
+
+		CScrollBarUI* pHorizontalScrollBar = m_pLayout->GetHorizontalScrollBar();
+		if (pHorizontalScrollBar)
+		{
+			LPCTSTR pDefaultAttributes = m_pOwner->GetManager()->GetDefaultAttributeList(_T("HScrollBar"));
+			if( pDefaultAttributes )
+				pHorizontalScrollBar->SetAttributeList(pDefaultAttributes);
+		}
+      
         return 0;
     }
     else if( uMsg == WM_CLOSE ) {
@@ -345,7 +374,7 @@ UINT CComboWnd::GetClassStyle() const
 ////////////////////////////////////////////////////////
 
 
-CComboUI::CComboUI() : m_pWindow(NULL), m_iCurSel(-1), m_uButtonState(0)
+CComboUI::CComboUI() : m_pWindow(NULL), m_iCurSel(-1), m_uButtonState(0),m_dwTextColor(0),m_dwDisabledTextColor(0),m_iFont(-1),m_uTextStyle(DT_VCENTER|DT_SINGLELINE|DT_LEFT)
 {
     m_szDropBox = CDuiSize(0, 150);
     ::ZeroMemory(&m_rcTextPadding, sizeof(m_rcTextPadding));
@@ -755,6 +784,38 @@ void CComboUI::SetShowText(bool flag)
 	m_bShowText = flag;
 	Invalidate();
 }
+void CComboUI::SetTextColor(DWORD dwTextColor)
+{
+	m_dwTextColor = dwTextColor;
+	Invalidate();
+}
+
+DWORD CComboUI::GetTextColor() const
+{
+	return m_dwTextColor;
+}
+
+void CComboUI::SetFont(int index)
+{
+	m_iFont = index;
+	Invalidate();
+}
+
+int CComboUI::GetFont() const
+{
+	return m_iFont;
+}
+
+void CComboUI::SetDisabledTextColor(DWORD dwTextColor)
+{
+	m_dwDisabledTextColor = dwTextColor;
+	Invalidate();
+}
+
+DWORD CComboUI::GetDisabledTextColor() const
+{
+	return m_dwDisabledTextColor;
+}
 
 RECT CComboUI::GetTextPadding() const
 {
@@ -1097,7 +1158,35 @@ void CComboUI::SetAttribute(LPCTSTR pstrName, LPCTSTR pstrValue)
         rcTextPadding.bottom = _tcstol(pstr + 1, &pstr, 10); ASSERT(pstr);    
         SetTextPadding(rcTextPadding);
     }
+	else if( _tcscmp(pstrName, _T("align")) == 0 ) {
+		if( _tcsstr(pstrValue, _T("left")) != NULL ) {
+			m_uTextStyle &= ~(DT_CENTER | DT_RIGHT);
+			m_uTextStyle |= DT_LEFT;
+		}
+		if( _tcsstr(pstrValue, _T("center")) != NULL ) {
+			m_uTextStyle &= ~(DT_LEFT | DT_RIGHT);
+			m_uTextStyle |= DT_CENTER;
+		}
+		if( _tcsstr(pstrValue, _T("right")) != NULL ) {
+			m_uTextStyle &= ~(DT_LEFT | DT_CENTER);
+			m_uTextStyle |= DT_RIGHT;
+		}
+	}
+	else if( _tcscmp(pstrName, _T("font")) == 0 ) SetFont(_ttoi(pstrValue));
+	else if( _tcscmp(pstrName, _T("textcolor")) == 0 ) {
+		if( *pstrValue == _T('#')) pstrValue = ::CharNext(pstrValue);
+		LPTSTR pstr = NULL;
+		DWORD clrColor = _tcstoul(pstrValue, &pstr, 16);
+		SetTextColor(clrColor);
+	}
+	else if( _tcscmp(pstrName, _T("disabledtextcolor")) == 0 ) {
+		if( *pstrValue == _T('#')) pstrValue = ::CharNext(pstrValue);
+		LPTSTR pstr = NULL;
+		DWORD clrColor = _tcstoul(pstrValue, &pstr, 16);
+		SetDisabledTextColor(clrColor);
+	}
 	else if( _tcscmp(pstrName, _T("showtext")) == 0 ) SetShowText(_tcscmp(pstrValue, _T("true")) == 0);
+	else if( _tcscmp(pstrName, _T("selectedid")) == 0 ) SelectItem(_ttoi(pstrValue));
     else if( _tcscmp(pstrName, _T("normalimage")) == 0 ) SetNormalImage(pstrValue);
     else if( _tcscmp(pstrName, _T("hotimage")) == 0 ) SetHotImage(pstrValue);
     else if( _tcscmp(pstrName, _T("pushedimage")) == 0 ) SetPushedImage(pstrValue);
@@ -1209,6 +1298,10 @@ void CComboUI::SetAttribute(LPCTSTR pstrName, LPCTSTR pstrValue)
         SetItemHLineColor(clrColor);
     }
     else if( _tcscmp(pstrName, _T("itemshowhtml")) == 0 ) SetItemShowHtml(_tcscmp(pstrValue, _T("true")) == 0);
+	else if (_tcscmp(pstrName, _T("vscrollbar")) == 0)	m_sVscrollbar = pstrValue;
+	else if (_tcscmp(pstrName, _T("hscrollbar")) == 0)	m_sHscrollbar = pstrValue;
+	else if( _tcscmp(pstrName, _T("vscrollbarstyle")) == 0 )	m_sVscrollbarStyle = pstrValue;
+	else if( _tcscmp(pstrName, _T("hscrollbarstyle")) == 0 )	m_sHscrollStyle = pstrValue;
     else CContainerUI::SetAttribute(pstrName, pstrValue);
 }
 
@@ -1254,7 +1347,11 @@ void CComboUI::PaintText(HDC hDC)
         CControlUI* pControl = static_cast<CControlUI*>(m_items[m_iCurSel]);
         IListItemUI* pElement = static_cast<IListItemUI*>(pControl->GetInterface(DUI_CTR_ILISTITEM));
         if( pElement != NULL ) {
-            pElement->DrawItemText(hDC, rcText);
+            //pElement->DrawItemText(hDC, rcText);
+			if (IsEnabled())
+				CRenderEngine::DrawText(hDC,m_pManager,rcText,pControl->GetText(),m_dwTextColor,m_iFont,m_uTextStyle);
+			else
+				CRenderEngine::DrawText(hDC,m_pManager,rcText,pControl->GetText(),m_dwDisabledTextColor,m_iFont,m_uTextStyle);
         }
         else {
             RECT rcOldPos = pControl->GetPos();
@@ -1263,6 +1360,26 @@ void CComboUI::PaintText(HDC hDC)
             pControl->SetPos(rcOldPos, false);
         }
     }
+}
+
+LPCTSTR CComboUI::GetVscrollbar() const
+{
+	return m_sVscrollbar;
+}
+
+LPCTSTR CComboUI::GetHscrollbar() const
+{
+	return m_sHscrollbar;
+}
+
+LPCTSTR CComboUI::GetVscrollStyle() const
+{
+	return m_sVscrollbarStyle;
+}
+
+LPCTSTR CComboUI::GetHscrollStyle() const
+{
+	return m_sHscrollStyle;
 }
 
 } // namespace DuiLib

--- a/DuiLib/Control/UICombo.h
+++ b/DuiLib/Control/UICombo.h
@@ -48,6 +48,12 @@ public:
 
 	bool GetShowText() const;
 	void SetShowText(bool flag);
+	void SetTextColor(DWORD dwTextColor);
+	DWORD GetTextColor() const;
+	void SetDisabledTextColor(DWORD dwTextColor);
+	DWORD GetDisabledTextColor() const;
+	void SetFont(int index);
+	int GetFont() const;
     RECT GetTextPadding() const;
     void SetTextPadding(RECT rc);
     LPCTSTR GetNormalImage() const;
@@ -117,6 +123,11 @@ public:
     void PaintText(HDC hDC);
     void PaintStatusImage(HDC hDC);
 
+	LPCTSTR GetVscrollbar() const;
+	LPCTSTR GetHscrollbar() const;
+	LPCTSTR GetVscrollStyle() const;
+	LPCTSTR GetHscrollStyle() const;
+
 protected:
     CComboWnd* m_pWindow;
 
@@ -125,8 +136,16 @@ protected:
 	bool m_bSelectCloseFlag;
     RECT m_rcTextPadding;
     CDuiString m_sDropBoxAttributes;
+	CDuiString m_sVscrollbar;
+	CDuiString m_sVscrollbarStyle;
+	CDuiString m_sHscrollbar;
+	CDuiString m_sHscrollStyle;
     SIZE m_szDropBox;
     UINT m_uButtonState;
+	int		m_iFont;
+	DWORD	m_dwTextColor;
+	DWORD	m_dwDisabledTextColor;
+	UINT	m_uTextStyle;
 
 	TDrawInfo m_diNormal;
     TDrawInfo m_diHot;

--- a/DuiLib/Control/UIScrollBar.cpp
+++ b/DuiLib/Control/UIScrollBar.cpp
@@ -857,7 +857,7 @@ void CScrollBarUI::DoEvent(TEventUI& event)
 	}
 	if( event.Type == UIEVENT_MOUSELEAVE )
 	{
-        if( ::PtInRect(&m_rcItem, event.ptMouse ) ) {
+        if( !::PtInRect(&m_rcItem, event.ptMouse ) ) {
             if( IsEnabled() ) {
                 m_uButton1State &= ~UISTATE_HOT;
                 m_uButton2State &= ~UISTATE_HOT;

--- a/DuiLib/Control/UIWebBrowser.cpp
+++ b/DuiLib/Control/UIWebBrowser.cpp
@@ -118,6 +118,12 @@ STDMETHODIMP CWebBrowserUI::Invoke( DISPID dispIdMember, REFIID riid, LCID lcid,
 // 			TRACE(_T("PropertyChange(%s)\n"), pDispParams->rgvarg[0].bstrVal);
 // 		}
 // 		break;
+	case DISPID_WINDOWCLOSING:
+		WindowClosing(
+			pDispParams->rgvarg[1].boolVal,
+			pDispParams->rgvarg[0].pboolVal
+			);
+		break;
 	default:
 		return DISP_E_MEMBERNOTFOUND;
 	}
@@ -264,6 +270,14 @@ void CWebBrowserUI::CommandStateChange(long Command,VARIANT_BOOL Enable)
 	if (m_pWebBrowserEventHandler)
 	{
 		m_pWebBrowserEventHandler->CommandStateChange(Command,Enable);
+	}
+}
+
+void DuiLib::CWebBrowserUI::WindowClosing(VARIANT_BOOL IsChildWindow, VARIANT_BOOL *Cancel)
+{
+	if (m_pWebBrowserEventHandler)
+	{
+		m_pWebBrowserEventHandler->WindowClosing(IsChildWindow,Cancel);
 	}
 }
 

--- a/DuiLib/Control/UIWebBrowser.h
+++ b/DuiLib/Control/UIWebBrowser.h
@@ -63,7 +63,8 @@ namespace DuiLib
 		void ProgressChange(LONG nProgress, LONG nProgressMax);
 		void NewWindow3(IDispatch **pDisp, VARIANT_BOOL *&Cancel, DWORD dwFlags, BSTR bstrUrlContext, BSTR bstrUrl);
 		void CommandStateChange(long Command,VARIANT_BOOL Enable);
-
+		void WindowClosing(VARIANT_BOOL IsChildWindow, VARIANT_BOOL *Cancel);
+		
 	public:
 		virtual LPCTSTR GetClass() const;
 		virtual LPVOID GetInterface( LPCTSTR pstrName );

--- a/DuiLib/Utils/WebBrowserEventHandler.h
+++ b/DuiLib/Utils/WebBrowserEventHandler.h
@@ -18,6 +18,7 @@ namespace DuiLib
 		virtual void ProgressChange(LONG nProgress, LONG nProgressMax){}
 		virtual void NewWindow3(IDispatch **pDisp, VARIANT_BOOL *&Cancel, DWORD dwFlags, BSTR bstrUrlContext, BSTR bstrUrl){}
 		virtual void CommandStateChange(long Command,VARIANT_BOOL Enable){};
+		virtual void WindowClosing(VARIANT_BOOL IsChildWindow, VARIANT_BOOL *Cancel){};
 
 		// interface IDocHostUIHandler
 		virtual HRESULT STDMETHODCALLTYPE ShowContextMenu(


### PR DESCRIPTION
一、
修复滚动条进入hot状态后，不能正确退出Hot状态的问题；
二、
1.给Combo标签增加selectedid属性解析，在xml中直接配置默认的选项；
2.给Combo增加textcolor/font/align属性，可自由配置Combo上面显示的文字的颜色/字体/水平对齐方式；
3.给combo的下拉窗口增加INotifyUI过滤，对某些消息（DUI_MSGTYPE_ITEMCLICK、DUI_MSGTYPE_ITEMACTIVATE、DUI_MSGTYPE_LINK、DUI_MSGTYPE_CLICK）进行转发以便于combo所在的窗体也能够收到相应notify通知；
4.combo下拉框的item抛出的notify采用异步方式,避免下拉框同步通知函数还未处理完毕时，下拉框就已经销毁从而引发的崩溃。（比如同步方式时，在下拉框item的点击事件中创建新的模态窗口等）；
5.修复combo下拉框的滚动条不能使用default标签中定义的滚动条样式的问题；
6.修复Combo下拉框滚动条相关标签vscrollbar/hscrollbar/vscrollbarstyle/hscrollbarstyle无效问题；
三、
给Webbrowser控件补充上对js的window.close的事件的响应，并在WebBrowerEventHandler中增加响应的虚函数接口