### PR TITLE
修复TabLayout中存在的一处问题

### DIFF
--- a/DuiLib/Layout/UITabLayout.cpp
+++ b/DuiLib/Layout/UITabLayout.cpp
@@ -104,12 +104,16 @@ namespace DuiLib
 		m_iCurSel = iIndex;
 		for( int it = 0; it < m_items.GetSize(); it++ )
 		{
-			if( it == iIndex ) {
-				GetItemAt(it)->SetVisible(true);
-				GetItemAt(it)->SetFocus();
-			}
-			else GetItemAt(it)->SetVisible(false);
+			GetItemAt(it)->SetVisible(false);
 		}
+        for (int it = 0; it < m_items.GetSize(); it++)
+        {
+            if (it == iIndex) {
+                GetItemAt(it)->SetVisible(true);
+                GetItemAt(it)->SetFocus();
+                break;
+            }
+        }
 		NeedParentUpdate();
 
 		if( m_pManager != NULL ) {


### PR DESCRIPTION
当使用自定义标签初始化TabLayout控件时，如果在同一个Layout控件中使用多个相同的标签:
```
<TabLayout` height="400" bkcolor="#00000000"  float="false" name="main_switch">
      <HorizontalLayout>
        <Main_Libpath/>
      </HorizontalLayout>
      <HorizontalLayout>
        <Main_Libpath/>
      </HorizontalLayout>
</TabLayout>
```
在Tab切换的时候，如果从第一个Tab切换为第二个Tab时不会发生问题，第二个Tab切换为第一个会发生
控件消失的问题，这里主要是因为TabLayout控件的SelectItem函数中:
```
        for (int it = 0; it < m_items.GetSize(); it++)            //从小到大遍历
        {
            if (it == iIndex) {
                GetItemAt(it)->SetVisible(true);                  //(先调用这个)设置Tab=1为显示（EVENT_LOAD_RESOURCE）控件
                GetItemAt(it)->SetFocus();
            }
            else GetItemAt(it)->SetVisible(false);                //(后调用这个)将Tab=2设置为消失，如果it指向的对象相同时(标签相同)，就会导致先设置该控件为显示，接着将该控件设置为消失的情况的发生
        }       
```
