### PR TITLE
修复 CContainerUI::DoPaint 绘制区域超出指定范围

### DIFF
--- a/DuiLib/Core/UIRender.cpp
+++ b/DuiLib/Core/UIRender.cpp
@@ -74,7 +74,8 @@ void CRenderClip::GenerateClip(HDC hDC, RECT rc, CRenderClip& clip)
     ::GetClipBox(hDC, &rcClip);
     clip.hOldRgn = ::CreateRectRgnIndirect(&rcClip);
     clip.hRgn = ::CreateRectRgnIndirect(&rc);
-    ::ExtSelectClipRgn(hDC, clip.hRgn, RGN_AND);
+    ::CombineRgn(clip.hRgn, clip.hRgn, clip.hOldRgn, RGN_AND);
+    ::SelectClipRgn(hDC, clip.hRgn);
     clip.hDC = hDC;
     clip.rcItem = rc;
 }
@@ -87,7 +88,8 @@ void CRenderClip::GenerateRoundClip(HDC hDC, RECT rc, RECT rcItem, int width, in
     clip.hRgn = ::CreateRectRgnIndirect(&rc);
     HRGN hRgnItem = ::CreateRoundRectRgn(rcItem.left, rcItem.top, rcItem.right + 1, rcItem.bottom + 1, width, height);
     ::CombineRgn(clip.hRgn, clip.hRgn, hRgnItem, RGN_AND);
-    ::ExtSelectClipRgn(hDC, clip.hRgn, RGN_AND);
+    ::CombineRgn(clip.hRgn, clip.hRgn, clip.hOldRgn, RGN_AND);
+    ::SelectClipRgn(hDC, clip.hRgn);
     clip.hDC = hDC;
     clip.rcItem = rc;
     ::DeleteObject(hRgnItem);


### PR DESCRIPTION
- 问题重现：使用如下 xml 生成界面。
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Window size="1200,800">
    <VerticalLayout bkcolor="#FF008800">
        <VerticalLayout bkcolor="#FF880088" float="true" pos="100,100,560,560" vscrollbar="true" inset="30,30,30,30">
            <VerticalLayout height="100" width="400" bkcolor="#FF440000">
                <Control bkcolor="#FF000088" float="true" pos="0,0,400,90" />
                <Control bkcolor="#FF123000" float="false" pos="0,0,400,90" />
            </VerticalLayout>
            <VerticalLayout height="100" width="400" bkcolor="#FF440000">
                <Control bkcolor="#FF000088" float="true" pos="0,0,400,90" />
                <Control bkcolor="#FF123000" float="false" pos="0,0,400,90" />
            </VerticalLayout>
            <VerticalLayout height="100" width="400" bkcolor="#FF440000">
                <Control bkcolor="#FF000088" float="true" pos="0,0,400,90" />
                <Control bkcolor="#FF123000" float="false" pos="0,0,400,90" />
            </VerticalLayout>
            <VerticalLayout height="100" width="400" bkcolor="#FF440000">
                <Control bkcolor="#FF000088" float="true" pos="0,0,400,90" />
                <Control bkcolor="#FF123000" float="false" pos="0,0,400,90" />
            </VerticalLayout>
            <VerticalLayout height="100" width="400" bkcolor="#FF440000">
                <Control bkcolor="#FF000088" float="true" pos="0,0,400,90" />
                <Control bkcolor="#FF123000" float="false" pos="0,0,400,90" />
            </VerticalLayout>
            <VerticalLayout height="100" width="400" bkcolor="#FF440000">
                <Control bkcolor="#FF000088" float="true" pos="0,0,400,90" />
                <Control bkcolor="#FF123000" float="false" pos="0,0,400,90" />
            </VerticalLayout>

        </VerticalLayout>
    </VerticalLayout>
</Window>
```
并在区域内滚动鼠标滚轮，会发现上下边缘的元素绘制时超出了 inset 的范围。
![image](https://user-images.githubusercontent.com/8768331/44799153-d5f0f900-abe5-11e8-8f3c-142d205741a4.png)
若最小化再最大化，情况更甚。
![image](https://user-images.githubusercontent.com/8768331/44799253-0a64b500-abe6-11e8-948c-fe3f04abb479.png)

- 原因排查：经查询，是如下 code 出现了问题。
```
bool CContainerUI::DoPaint(HDC hDC, const RECT& rcPaint, CControlUI* pStopControl)
...
if (pControl->IsFloat()) {
    if (!::IntersectRect(&rcTemp, &m_rcItem, &pControl->GetPos())) continue;
    CRenderClip::UseOldClipBegin(hDC, childClip);
    if (!pControl->Paint(hDC, rcPaint, pStopControl)) return false;
    CRenderClip::UseOldClipEnd(hDC, childClip);
}
```
如果该 control 为 float，则使用回原先的 clip region，等绘制完毕后再设置回现在的 clip region。
然而，UseOldClipEnd 中仅是将 hDC 的 clip region 设置为 childClip.hRgn。而 childClip.hRgn 在创建时的逻辑并没有保证与 hDC 当前的 clip region 为相同范围的区域。就有可能造成执行 UseOldClipEnd 后，hDC 的 clip region 与执行 UseOldClipBegin 之前的 clip region 不同。

- 解决：方法也很简单，保证 childClip.hRgn 创建时使用的是当前 hDC 的实际 clip region 即可。


