### PR TITLE
支持在 CEditUI 控件中禁用右键菜单

### DIFF
--- a/DuiLib/Control/UIEdit.cpp
+++ b/DuiLib/Control/UIEdit.cpp
@@ -207,6 +207,11 @@ namespace DuiLib
 			}
 			bHandled = FALSE;
 		}
+		else if ( uMsg == WM_CONTEXTMENU ) {
+			if (m_pOwner->IsContextMenuUsed()) {
+				bHandled = FALSE;
+			}
+		}
 		else bHandled = FALSE;
 		if( !bHandled ) return CWindowWnd::HandleMessage(uMsg, wParam, lParam);
 		return lRes;


### PR DESCRIPTION
- 问题重现：使用如下 xml 生成界面。
```xml
<?xml version="1.0" encoding="UTF-8"?>
<Window size="200,200">
    <VerticalLayout>
        <Edit pos="10,10,110,30" float="true" menu="false">
        </Edit>
    </VerticalLayout>
</Window>
```

CControlUI 中有 attribute `menu` 默认值为 `false`。然而在 CEditUI 控件中，点击右键依然能够呼出 context menu。

![image](https://user-images.githubusercontent.com/8768331/46746513-c6cf9180-cce1-11e8-8dbb-e44c1ead91f6.png)

- 原因排查：

因 CEditUI 中实际使用了 CEditWnd 来显示 edit 控件，而 CEditWnd 的消息处理并不在 DuiLib 的消息流程中。需要单独处理。

- 解决：

在 CEditWnd 的 HandleMessage 中加入对 WM_CONTEXTMENU 消息的处理。owner 不支持 context menu 时，吃掉 WM_CONTEXTMENU。