### PR TITLE
修正RichEdit光标超出父容器显示范围的问题

### DIFF
--- a/DuiLib/Control/UIRichEdit.cpp
+++ b/DuiLib/Control/UIRichEdit.cpp
@@ -523,8 +523,8 @@ BOOL CTxtWinHost::TxCreateCaret(HBITMAP hbmp, INT xWidth, INT yHeight)
 
 BOOL CTxtWinHost::TxShowCaret(BOOL fShow)
 {
-	fShowCaret = fShow && !fNoCaret;
-    if(fShowCaret)
+	fShowCaret = fShow;
+    if(fShow && !fNoCaret)
         return ::ShowCaret(m_re->GetManager()->GetPaintWindow());
     else
         return ::HideCaret(m_re->GetManager()->GetPaintWindow());

--- a/DuiLib/Control/UIRichEdit.cpp
+++ b/DuiLib/Control/UIRichEdit.cpp
@@ -552,10 +552,9 @@ BOOL CTxtWinHost::TxSetCaretPos(INT x, INT y)
     if (m_re && m_re->GetManager())
     {
         POINT ptNew = { x, y };
-        POINT ptNew2 = { x, y + GetCaretHeight() };
-        CControlUI *pTop = m_re->GetManager()->FindControl(ptNew);
-        CControlUI *pTop2 = m_re->GetManager()->FindControl(ptNew2);
-        if ( pTop != m_re || pTop2 != m_re)
+        POINT ptNew2 = { x + GetCaretWidth(), y + GetCaretHeight() };
+        if (m_re->GetManager()->FindControl(ptNew) != m_re 
+            || m_re->GetManager()->FindControl(ptNew2) != m_re)
             fNoCaret = TRUE;
         else
             fNoCaret = FALSE;


### PR DESCRIPTION
滚动容器，使RichEdit光标超出容器显示范围，光标不消失并会弄脏其他控件
![bug1](https://user-images.githubusercontent.com/8545651/49008180-2f969e80-f1a8-11e8-9dfc-0c8ef44346fe.png)
