### PR TITLE
修正win7下，RichEdit滚动超出界面时字体变小的bug

### DIFF
--- a/DuiLib/Control/UIRichEdit.cpp
+++ b/DuiLib/Control/UIRichEdit.cpp
@@ -500,11 +500,12 @@ BOOL CTxtWinHost::TxSetScrollPos (INT fnBar, INT nPos, BOOL fRedraw)
 
 void CTxtWinHost::TxInvalidateRect(LPCRECT prc, BOOL fMode)
 {
-    if( prc == NULL ) {
-        m_re->GetManager()->Invalidate(rcClient);
-        return;
-    }
-    RECT rc = *prc;
+    //Fixed Issue In Win 7，不能让Invalidate修改rcClient，否则文字可能会被缩小
+    RECT rc = {};
+    if (prc == NULL)
+        rc = rcClient;
+    else
+        rc = *prc;
     m_re->GetManager()->Invalidate(rc);
 }
 


### PR DESCRIPTION

![scorll_bug](https://user-images.githubusercontent.com/8545651/53313582-0267a280-38f5-11e9-8e98-91b75317f94d.gif)
