### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ Duilib是一个Windows下免费开源的DirectUI界面库，由于简约易扩�
 
 欢迎为Duilib提供功能改进、代码修补、bug反馈、使用文档和献计献策，让我们一起把Duilib做的更好！
 
+# 快速安装
+
+您可以使用[vcpkg](https://github.com/Microsoft/vcpkg)库管理器下载并安装duilib:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install duilib
+
+vcpkg中的duilib库由Microsoft团队成员和社区贡献者保持最新状态。如果版本过时，请在vcpkg存储库上[创建问题或请求请求](https://github.com/Microsoft/vcpkg)。
+
 # 基于Duilib的软件不完全列表
 Duilib自2010年8月21日发布以来，获得了众多开发者和大公司的信赖，在各行各业的软件中得到了广泛应用，以下是一个作者知道不完全列表，欢迎大家补充指正
 https://github.com/duilib/duilib/wiki/%E5%9F%BA%E4%BA%8EDuilib%E7%9A%84%E8%BD%AF%E4%BB%B6%E4%B8%8D%E5%AE%8C%E5%85%A8%E5%88%97%E8%A1%A8


### PR DESCRIPTION
Duilib is available as a port in vcpkg, a C++ library manager that simplifies installation for duilib and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build duilib, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.