### PR TITLE
[cmake] 更新cmake配置

### DIFF
--- a/360SafeDemo/CMakeLists.txt
+++ b/360SafeDemo/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(360safedemo ${source_files})
 set_target_properties(360safedemo PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
 add_dependencies(360safedemo duilib)
 target_link_libraries(360safedemo duilib)
-add_custom_command(TARGET 360safedemo POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${PROJECT_BINARY_DIR}/bin/360safedemo.exe ${PROJECT_SOURCE_DIR}/bin/360safedemo.exe)
+
+install(
+  TARGETS 360safedemo
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ cmake_minimum_required(VERSION 2.8)
 
 project(dui)
 
+option(DUILIB_BUILD_EXAMPLES "Build examples" OFF)
+
 message(STATUS," CMake project files for duilib")
 
 # this line is for UNICODE release,which is required by DuiDesigner 
@@ -17,10 +19,15 @@ add_definitions(-DUNICODE -D_UNICODE)
 
 # add each CMake file
 add_subdirectory(duilib)
-add_subdirectory(360SafeDemo)
-add_subdirectory(FlashDemo)
-add_subdirectory(GameDemo)
-add_subdirectory(ListDemo)
-# add_subdirectory(MenuDemo) the sources in this project has error
-add_subdirectory(QQDemo)
-add_subdirectory(RichListDemo)
+
+if (DUILIB_BUILD_EXAMPLES)
+    add_subdirectory(360SafeDemo)
+    add_subdirectory(FlashDemo)
+    add_subdirectory(GameDemo)
+    add_subdirectory(ListDemo)
+    # add_subdirectory(MenuDemo) the sources in this project has error
+    add_subdirectory(QQDemo)
+    add_subdirectory(RichListDemo)
+endif()
+
+install(FILES ${PROJECT_SOURCE_DIR}/LICENSE DESTINATION share/${PROJECT_NAME})

--- a/DuiLib/CMakeLists.txt
+++ b/DuiLib/CMakeLists.txt
@@ -19,7 +19,7 @@ add_library(duilib SHARED ${Control_src} ${Core_src} ${Layout_src} ${Utils_src} 
 
 add_definitions(-DUILIB_EXPORTS)
 target_link_libraries(duilib comctl32)
-target_include_directories(duilib PUBLIC $<INSTALL_INTERFACE>:include)
+target_include_directories(duilib PUBLIC $<INSTALL_INTERFACE:include>)
 set_target_properties(duilib PROPERTIES OUTPUT_NAME "duilib")
 
 # Install headers

--- a/DuiLib/CMakeLists.txt
+++ b/DuiLib/CMakeLists.txt
@@ -45,6 +45,6 @@ install(
 
 # Install cmake configure files
 install(EXPORT duilib-config
-    NAMESPACE dui:::
+    NAMESPACE dui::
     DESTINATION share/duilib
 )

--- a/DuiLib/CMakeLists.txt
+++ b/DuiLib/CMakeLists.txt
@@ -20,6 +20,31 @@ add_library(duilib SHARED ${Control_src} ${Core_src} ${Layout_src} ${Utils_src} 
 add_definitions(-DUILIB_EXPORTS)
 target_link_libraries(duilib comctl32)
 set_target_properties(duilib PROPERTIES OUTPUT_NAME "duilib")
-add_custom_command(TARGET duilib POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${PROJECT_BINARY_DIR}/lib/duilib.dll ${PROJECT_SOURCE_DIR}/bin/duilib.dll)
+
+# Install headers
+file(GLOB DUILIB_PUBLIC_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+file(GLOB DUILIB_CORE_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/Core/*.h")
+file(GLOB DUILIB_UTILS_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/Utils/*.h")
+file(GLOB DUILIB_CONTROL_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/Control/*.h")
+file(GLOB DUILIB_LAYOUT_HDRS "${CMAKE_CURRENT_SOURCE_DIR}/Layout/*.h")
+
+install(FILES ${DUILIB_PUBLIC_HDRS}     DESTINATION include)
+install(FILES ${DUILIB_CORE_HDRS}       DESTINATION include/Core)
+install(FILES ${DUILIB_UTILS_HDRS}      DESTINATION include/Utils)
+install(FILES ${DUILIB_CONTROL_HDRS}    DESTINATION include/Control)
+install(FILES ${DUILIB_LAYOUT_HDRS}     DESTINATION include/Layout)
+
+# Install binaries
+install(
+  TARGETS duilib
+  EXPORT  duilib-config
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+
+# Install cmake configure files
+install(EXPORT duilib-config
+    NAMESPACE dui:::
+    DESTINATION share/duilib
+)

--- a/DuiLib/CMakeLists.txt
+++ b/DuiLib/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(duilib SHARED ${Control_src} ${Core_src} ${Layout_src} ${Utils_src} 
 
 add_definitions(-DUILIB_EXPORTS)
 target_link_libraries(duilib comctl32)
+target_include_directories(duilib PUBLIC $<INSTALL_INTERFACE>:include)
 set_target_properties(duilib PROPERTIES OUTPUT_NAME "duilib")
 
 # Install headers

--- a/DuiLib/CMakeLists.txt
+++ b/DuiLib/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(duilib SHARED ${Control_src} ${Core_src} ${Layout_src} ${Utils_src} 
 add_definitions(-DUILIB_EXPORTS)
 target_link_libraries(duilib comctl32)
 target_include_directories(duilib PUBLIC $<INSTALL_INTERFACE:include>)
+target_compile_definitions(duilib PRIVATE UILIB_EXPORTS)
 set_target_properties(duilib PROPERTIES OUTPUT_NAME "duilib")
 
 # Install headers

--- a/FlashDemo/CMakeLists.txt
+++ b/FlashDemo/CMakeLists.txt
@@ -11,6 +11,9 @@ add_dependencies(FlashDemo duilib)
 target_link_libraries(FlashDemo duilib)
 set_target_properties(FlashDemo PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
 
-add_custom_command(TARGET FlashDemo POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${PROJECT_BINARY_DIR}/bin/FlashDemo.exe ${PROJECT_SOURCE_DIR}/bin/FlashDemo.exe)
+install(
+  TARGETS FlashDemo
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/GameDemo/CMakeLists.txt
+++ b/GameDemo/CMakeLists.txt
@@ -11,6 +11,9 @@ add_dependencies(GameDemo duilib)
 target_link_libraries(GameDemo duilib)
 set_target_properties(GameDemo PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
 
-add_custom_command(TARGET GameDemo POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${PROJECT_BINARY_DIR}/bin/GameDemo.exe ${PROJECT_SOURCE_DIR}/bin/GameDemo.exe)
+install(
+  TARGETS GameDemo
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/ListDemo/CMakeLists.txt
+++ b/ListDemo/CMakeLists.txt
@@ -11,6 +11,9 @@ add_dependencies(ListDemo duilib)
 target_link_libraries(ListDemo duilib)
 set_target_properties(ListDemo PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
 
-add_custom_command(TARGET ListDemo POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${PROJECT_BINARY_DIR}/bin/ListDemo.exe ${PROJECT_SOURCE_DIR}/bin/ListDemo.exe)
+install(
+  TARGETS ListDemo
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/MenuDemo/CMakeLists.txt
+++ b/MenuDemo/CMakeLists.txt
@@ -11,7 +11,9 @@ add_executable(MenuDemo ${SRC} MenuDemo.rc)
 set_target_properties(MenuDemo PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
 target_link_libraries(MenuDemo duilib)
 
-
-add_custom_command(TARGET MenuDemo POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${PROJECT_BINARY_DIR}/bin/MenuDemo.exe ${PROJECT_SOURCE_DIR}/bin/MenuDemo.exe)
+install(
+  TARGETS MenuDemo
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/QQDemo/CMakeLists.txt
+++ b/QQDemo/CMakeLists.txt
@@ -11,7 +11,9 @@ add_executable(QQDemo ${SRC} QQDemo.rc)
 set_target_properties(QQDemo PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
 target_link_libraries(QQDemo duilib)
 
-
-add_custom_command(TARGET QQDemo POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${PROJECT_BINARY_DIR}/bin/QQDemo.exe ${PROJECT_SOURCE_DIR}/bin/QQDemo.exe)
+install(
+  TARGETS QQDemo
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/RichListDemo/CMakeLists.txt
+++ b/RichListDemo/CMakeLists.txt
@@ -12,6 +12,9 @@ add_executable(RichListDemo ${SRC_LIST} RichListDemo.rc)
 set_target_properties(RichListDemo PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS")
 target_link_libraries(RichListDemo duilib)
 
-add_custom_command(TARGET RichListDemo POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different
-  ${PROJECT_BINARY_DIR}/bin/RichListDemo.exe ${PROJECT_SOURCE_DIR}/bin/RichListDemo.exe)
+install(
+  TARGETS RichListDemo
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)


### PR DESCRIPTION
哎我实在看不下去了，既然我要用，那就改善一下吧：
1. 增加安装头文件。
2. 增加导出cmake配置文件。
3. 增加安装License。
4. 增加选项`DUILIB_BUILD_EXAMPLES`以默认禁用编译示例工程。

如果以后要改善cmake部分可以@我。