### PR TITLE
fix CListBodyUI::SortItems failed

### DIFF
--- a/DuiLib/Control/UIList.cpp
+++ b/DuiLib/Control/UIList.cpp
@@ -1093,7 +1093,7 @@ bool CListBodyUI::SortItems(PULVCompareFunc pfnCompare, UINT_PTR dwData, int& iC
 	IListItemUI *pItem = NULL;
 	for (int i = 0; i < m_items.GetSize(); ++i)
 	{
-		pItem = (IListItemUI*)(static_cast<CControlUI*>(m_items[i])->GetInterface(TEXT("ListItem")));
+		pItem = (IListItemUI*)(static_cast<CControlUI*>(m_items[i])->GetInterface(DUI_CTR_ILISTITEM));
 		if (pItem)
 		{
 			pItem->SetIndex(i);


### PR DESCRIPTION
ListItem在系统内部已经修改成 IListItem， 由DUI_CTR_ILISTITEM指向，如果还是ListItem，会得到NULL的item，从而排序后位置不正常