### PR TITLE
🔧[fix]修复Duilib和MFC一起使用时，MFC窗口类析构但duilib窗口没有将GWLP_USERDATA设置为空导致的崩溃

### DIFF
--- a/DuiLib/Core/UIBase.cpp
+++ b/DuiLib/Core/UIBase.cpp
@@ -214,6 +214,10 @@ CWindowWnd::CWindowWnd() : m_hWnd(NULL), m_OldWndProc(::DefWindowProc), m_bSubcl
 {
 }
 
+CWindowWnd::~CWindowWnd() {
+    ::SetWindowLongPtr(m_hWnd, GWLP_USERDATA, 0L);
+}
+
 HWND CWindowWnd::GetHWND() const 
 { 
     return m_hWnd; 

--- a/DuiLib/Core/UIBase.h
+++ b/DuiLib/Core/UIBase.h
@@ -62,6 +62,7 @@ class DUILIB_API CWindowWnd
 {
 public:
     CWindowWnd();
+	virtual ~CWindowWnd();
 
     HWND GetHWND() const;
     operator HWND() const;


### PR DESCRIPTION
Duilib作为MFC子窗口，MFC对象销毁时，Duilib作为成员先销毁，WM_DESTROY消息过来时，duilib对象已经没有了
![image](https://github.com/user-attachments/assets/c8d96d43-92b9-48fb-95c1-c98427ef35b2)
