### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow vulnerabilities in string formatting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Buffer overflow vulnerabilities in string formatting
+**Vulnerability:** Found uses of `wvsprintf`, `wvnsprintf`, and `wsprintf` in `CDuiString::SmallFormat` and UI tracing functions, which write formatted strings into small, fixed-size buffers (`64` or `300` bytes) without proper bounds checking or potentially truncating without null-terminating safely.
+**Learning:** These Win32 API string formatting functions can easily cause buffer overflows if the resulting formatted string exceeds the buffer size, or lead to unsafe states if they don't null-terminate on truncation. The codebase uses these natively with `TCHAR` buffers.
+**Prevention:** Use safer alternatives like `_vsntprintf` and `_sntprintf` which allow specifying the maximum number of characters to write. Additionally, always explicitly null-terminate the buffer at the last index `szBuffer[lengthof(szBuffer) - 1] = _T('\0');` to ensure the string is safely terminated even if truncated.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ message(STATUS," CMake project files for duilib")
 add_definitions(-DUNICODE -D_UNICODE)
 
 # add each CMake file
-add_subdirectory(duilib)
+add_subdirectory(DuiLib)
 
 if (DUILIB_BUILD_EXAMPLES)
     add_subdirectory(360SafeDemo)

--- a/DuiLib/Core/UIBase.cpp
+++ b/DuiLib/Core/UIBase.cpp
@@ -17,7 +17,7 @@ void DUILIB_API DUI__Trace(LPCTSTR pstrFormat, ...)
     TCHAR szBuffer[300] = { 0 };
     va_list args;
     va_start(args, pstrFormat);
-    ::wvnsprintf(szBuffer, lengthof(szBuffer) - 2, pstrFormat, args);
+    _vsntprintf(szBuffer, lengthof(szBuffer) - 2, pstrFormat, args);
     _tcscat(szBuffer, _T("\n"));
     va_end(args);
     ::OutputDebugString(szBuffer);
@@ -82,7 +82,8 @@ LPCTSTR DUI__TraceMsg(UINT uMsg)
     MSGDEF(WM_GETTEXT);
     MSGDEF(WM_GETTEXTLENGTH);   
     static TCHAR szMsg[10];
-    ::wsprintf(szMsg, _T("0x%04X"), uMsg);
+    _sntprintf(szMsg, lengthof(szMsg) - 1, _T("0x%04X"), uMsg);
+	szMsg[lengthof(szMsg) - 1] = _T('\0');
     return szMsg;
 }
 

--- a/DuiLib/Utils/Utils.cpp
+++ b/DuiLib/Utils/Utils.cpp
@@ -790,7 +790,8 @@ namespace DuiLib
 		TCHAR szBuffer[64] = { 0 };
 		va_list argList;
 		va_start(argList, pstrFormat);
-		int iRet = ::wvsprintf(szBuffer, sFormat, argList);
+		int iRet = _vsntprintf(szBuffer, lengthof(szBuffer) - 1, sFormat, argList);
+		szBuffer[lengthof(szBuffer) - 1] = _T('\0');
 		va_end(argList);
 		Assign(szBuffer);
 		return iRet;


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix buffer overflow vulnerabilities

🚨 Severity: HIGH
💡 Vulnerability: Used unsafe `wvsprintf` and `wsprintf` Win32 API calls which format strings without bounds checking into small fixed-size stack buffers (`64` and `300` `TCHAR` sizes).
🎯 Impact: Attackers who control the input string or formatting arguments could write beyond the allocated buffer, leading to stack buffer overflow and potential remote code execution or crashes.
🔧 Fix: Replaced unbounded formatting functions with their bounds-checked equivalents (`_vsntprintf`, `_sntprintf`). Explicitly null-terminated the buffers to guarantee correct state even if the strings get truncated. Also corrected `duilib` to `DuiLib` in `CMakeLists.txt`.
✅ Verification: Code review rated "Correct". Building failed appropriately on Linux due to Windows SDK headers dependencies (`<windows.h>`) as expected for this Windows UI project. CMake configuration was successful after directory name fix.

---
*PR created automatically by Jules for task [8628366910736040223](https://jules.google.com/task/8628366910736040223) started by @wangchyz*