### PR TITLE
🛡️ Sentinel: [HIGH] Fix buffer overflow and format string vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-20 - Unbounded C-string Functions & Format String Bugs
+**Vulnerability:** Found uses of `strcpy` in `DuiLib/Utils/XUnzip.cpp` when compiled without `_UNICODE`. Found severe format string vulnerabilities and buffer overflows in `ListDemo/Main.cpp` using `_stprintf(szBuf, ...)` with unvalidated data formats.
+**Learning:** Legacy C/C++ string functions (`strcpy`, `sprintf`) are prone to buffer overflows, especially with untrusted data inputs or unbounded size structures. Passing untrusted strings as the format specifier to formatting functions allows arbitrary memory reads/writes.
+**Prevention:** Always use bounds-checked equivalents like `lstrcpynA` for explicit ANSI buffers. Use explicitly bounded `_sntprintf` and properly inject dynamic strings using `%s` formatting variables instead of directly into the format string template.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ message(STATUS," CMake project files for duilib")
 add_definitions(-DUNICODE -D_UNICODE)
 
 # add each CMake file
-add_subdirectory(duilib)
+add_subdirectory(DuiLib)
 
 if (DUILIB_BUILD_EXAMPLES)
     add_subdirectory(360SafeDemo)

--- a/DuiLib/Utils/XUnzip.cpp
+++ b/DuiLib/Utils/XUnzip.cpp
@@ -3451,7 +3451,7 @@ int unzLocateFile (unzFile file, const TCHAR *szFileName, int iCaseSensitivity)
 #ifdef _UNICODE
 	GetAnsiFileName(szFileName, szFileNameA, MAX_PATH-1);
 #else
-	strcpy(szFileNameA, szFileName);
+	lstrcpynA(szFileNameA, szFileName, MAX_PATH);
 #endif
 
 	// support Windows subdirectory by:daviyang35
@@ -3994,7 +3994,7 @@ ZRESULT TUnzip::Get(int index,ZIPENTRY *ze)
   if (lufread(extra,1,(uInt)extralen,uf->file)!=extralen) {delete[] extra; return ZR_READ;}
   //
   ze->index=uf->num_file;
-  strcpy(ze->name,fn);
+  lstrcpynA(ze->name, fn, MAX_PATH);
   // zip has an 'attribute' 32bit value. Its lower half is windows stuff
   // its upper half is standard unix attr.
   unsigned long a = ufi.external_fa;
@@ -4348,7 +4348,7 @@ ZRESULT GetZipItemW(HZIP hz, int index, ZIPENTRYW *zew)
 #ifdef _UNICODE
 		GetUnicodeFileName(ze.name, zew->name, MAX_PATH-1);
 #else
-		strcpy(zew->name, ze.name);
+		lstrcpynA(zew->name, ze.name, MAX_PATH);
 #endif
 	}
 	return lasterrorU;
@@ -4400,7 +4400,7 @@ ZRESULT FindZipItemW(HZIP hz, const TCHAR *name, bool ic, int *index, ZIPENTRYW 
 #ifdef _UNICODE
 		GetUnicodeFileName(ze.name, zew->name, MAX_PATH-1);
 #else
-		strcpy(zew->name, ze.name);
+		lstrcpynA(zew->name, ze.name, MAX_PATH);
 #endif
 	}
 

--- a/ListDemo/Main.cpp
+++ b/ListDemo/Main.cpp
@@ -144,7 +144,7 @@ public:
         switch (iSubItem)
         {
         case 0:
-            _stprintf(szBuf, _T("%d"), iIndex);
+            _sntprintf(szBuf, MAX_PATH - 1, _T("%d"), iIndex);
             break;
         case 1:
             {
@@ -153,10 +153,10 @@ public:
             LPWSTR lpText = new WCHAR[iLen + 1];
             ::ZeroMemory(lpText, (iLen + 1) * sizeof(WCHAR));
             ::MultiByteToWideChar(CP_ACP, 0, domain[iIndex].c_str(), -1, (LPWSTR)lpText, iLen) ;
-            _stprintf(szBuf, lpText);
+            _sntprintf(szBuf, MAX_PATH - 1, _T("%s"), lpText);
             delete[] lpText;
 #else
-            _stprintf(szBuf, domain[iIndex].c_str());
+            _sntprintf(szBuf, MAX_PATH - 1, _T("%s"), domain[iIndex].c_str());
 #endif
             }
             break;
@@ -167,10 +167,10 @@ public:
             LPWSTR lpText = new WCHAR[iLen + 1];
             ::ZeroMemory(lpText, (iLen + 1) * sizeof(WCHAR));
             ::MultiByteToWideChar(CP_ACP, 0, desc[iIndex].c_str(), -1, (LPWSTR)lpText, iLen) ;
-            _stprintf(szBuf, lpText);
+            _sntprintf(szBuf, MAX_PATH - 1, _T("%s"), lpText);
             delete[] lpText;
 #else
-            _stprintf(szBuf, desc[iIndex].c_str());
+            _sntprintf(szBuf, MAX_PATH - 1, _T("%s"), desc[iIndex].c_str());
 #endif
             }
             break;


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Buffer overflows and format string vulnerabilities in UI data parsing and unzipping operations.
🎯 Impact: An attacker providing a maliciously crafted ZIP archive or long domain name could crash the application or potentially execute arbitrary code by overwriting stack boundaries.
🔧 Fix: Replaced `strcpy` with `lstrcpynA` ensuring bounds checking. Fixed unsafe format string injection with `_sntprintf` and explicit `%s` formatters. Also patched `CMakeLists.txt` for case-sensitive build systems.
✅ Verification: Code syntax validation; manually checked to compile with Linux build tools up to the Windows SDK dependency point. Ensure bounds checks correctly constrain memory sizes.

---
*PR created automatically by Jules for task [7760456927255943070](https://jules.google.com/task/7760456927255943070) started by @wangchyz*